### PR TITLE
Added query map loader to pg client

### DIFF
--- a/pg/pg.go
+++ b/pg/pg.go
@@ -29,10 +29,14 @@ func NewPG() (*PG, error) {
 		return &PG{}, fmt.Errorf("PG ERROR: Could not open connection to postgres \n %s", err)
 	}
 
-	return &PG{
+	res := &PG{
 		Conn:     db,
 		QueryMap: make(map[string]string, 0),
-	}, nil
+	}
+
+	// TODO: Error handling when there is a queries dir.
+	_ = res.LoadQueryMap("queries")
+	return res, nil
 }
 
 // Parses a given base dirPath and stores all query files into

--- a/pg/pg_test.go
+++ b/pg/pg_test.go
@@ -7,22 +7,16 @@ import (
 	"github.com/aria-afk/go-get-tickets/utils"
 )
 
-func setup() {
-	os.WriteFile("pg_test.env", []byte("PG_CONN_STRING=postgresql://postgres:test@localhost/template1"), 0755)
-	utils.LoadEnv("pg_test.env")
-}
-
-func cleanup() {
-	os.Remove("pg_test.env")
-}
+var pg *PG
 
 func TestNewPG(t *testing.T) {
-	setup()
+	os.WriteFile("pg_test.env", []byte("PG_CONN_STRING=postgresql://postgres:test@localhost/template1"), 0755)
+	utils.LoadEnv("pg_test.env")
 
 	// Open connection
 	db, err := NewPG()
 	if err != nil {
-		cleanup()
+		os.Remove("pg_test.env")
 		t.Fatalf("Error creating new PG instance:\n%s", err)
 	}
 
@@ -31,9 +25,40 @@ func TestNewPG(t *testing.T) {
 	err = db.Conn.QueryRow("SELECT 1 + $1", 1).Scan(&response)
 
 	if response != 2 || err != nil {
-		cleanup()
+		os.Remove("pg_test.env")
 		t.Fatalf("Error preforming simple query:\n%s", err)
 	}
 
-	cleanup()
+	pg = db
+
+	os.Remove("pg_test.env")
+}
+
+func TestLoadQueryMap(t *testing.T) {
+	os.Mkdir("queries_test", 0755)
+	os.WriteFile("queries_test/one.sql", []byte("SELECT 1 + $1;"), 0755)
+	os.Mkdir("queries_test/nested", 0755)
+	os.WriteFile("queries_test/nested/two.sql", []byte("SELECT $1 + $2;"), 0755)
+
+	pg.LoadQueryMap("queries_test")
+
+	one, ok := pg.QueryMap["queries_test/one"]
+	if ok {
+		if one != "SELECT 1 + $1;" {
+			t.Fatalf("Query map loaded query_test/one.sql but did not parse its contents properly")
+		}
+	} else {
+		t.Fatalf("Query map did not load singly nested query queries_test/one.sql")
+	}
+
+	two, ok := pg.QueryMap["queries_test/nested/two"]
+	if ok {
+		if two != "SELECT $1 + $2;" {
+			t.Fatalf("Query map loaded query_test/nested/two.sql but did not parse its contents properly")
+		}
+	} else {
+		t.Fatalf("Query map did not load singly nested query queries_test/nested/two.sql")
+	}
+
+	os.RemoveAll("queries_test")
 }


### PR DESCRIPTION
We can now load .sql query files into a query map. We can always write inline strings too but I do like having the organization and ability to test locally a bit more.