### PR TITLE
Better way to load query files

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,5 @@
+package main
+
+import _ "github.com/aria-afk/go-get-tickets/queries"
+
+func main() {}

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 package main
 
-import _ "github.com/aria-afk/go-get-tickets/queries"
+import _ "github.com/aria-afk/go-get-tickets/queriesv2"
 
 func main() {}

--- a/queries/_test/test.sql
+++ b/queries/_test/test.sql
@@ -1,0 +1,1 @@
+SELECT * FROM users WHERE id = $1;

--- a/queries/lib.go
+++ b/queries/lib.go
@@ -7,11 +7,12 @@ import (
 )
 
 func parseQueryFile(path string) string {
+	basePath := formatBasePath()
 	// Ensure file is a valid .sql file
 	if path[len(path)-4:] != ".sql" {
 		panic(fmt.Sprintf("Provided file path is not a .sql file, given path: %s", path))
 	}
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(basePath + "/" + path)
 	if err != nil {
 		panic(fmt.Sprintf("Issue parsing query file [ %s ]\n Error: %s", path, err))
 	}
@@ -36,5 +37,3 @@ func formatBasePath() string {
 		panic("Given working dir does not have a mapping yet, please add it.")
 	}
 }
-
-var basePath = formatBasePath()

--- a/queries/lib.go
+++ b/queries/lib.go
@@ -1,0 +1,40 @@
+package queries
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func parseQueryFile(path string) string {
+	// Ensure file is a valid .sql file
+	if path[len(path)-4:] != ".sql" {
+		panic(fmt.Sprintf("Provided file path is not a .sql file, given path: %s", path))
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		panic(fmt.Sprintf("Issue parsing query file [ %s ]\n Error: %s", path, err))
+	}
+	return string(data)
+}
+
+// Ensure this package can be imported properly from any supported sub-package
+func formatBasePath() string {
+	absPath, err := filepath.Abs("./")
+	if err != nil {
+		panic(err)
+	}
+	basePath := filepath.Base(absPath)
+	switch basePath {
+	// Root dir
+	case "go-get-tickets":
+		return filepath.Join(absPath, "queries")
+	// This package (for queries_test)
+	case "queries":
+		return absPath
+	default:
+		panic("Given working dir does not have a mapping yet, please add it.")
+	}
+}
+
+var basePath = formatBasePath()

--- a/queries/lib.go
+++ b/queries/lib.go
@@ -30,7 +30,7 @@ func formatBasePath() string {
 	// Root dir
 	case "go-get-tickets":
 		return filepath.Join(absPath, "queries")
-	// This package (for queries_test)
+	// This package (for lib_test)
 	case "queries":
 		return absPath
 	default:

--- a/queries/lib.go
+++ b/queries/lib.go
@@ -8,7 +8,7 @@ import (
 
 func parseQueryFile(path string) string {
 	basePath := formatBasePath()
-	// Ensure file is a valid .sql file
+	// Ensure file has a .sql extension
 	if path[len(path)-4:] != ".sql" {
 		panic(fmt.Sprintf("Provided file path is not a .sql file, given path: %s", path))
 	}

--- a/queries/lib_test.go
+++ b/queries/lib_test.go
@@ -1,0 +1,23 @@
+package queries
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseQueryFilePass(t *testing.T) {
+	givenQuery := strings.TrimSuffix(testQuery, "\n")
+	expectedQuery := "SELECT * FROM users WHERE id = $1;"
+	if givenQuery != expectedQuery {
+		t.Errorf("Obtaining the query file didnt crash, however the file was not parsed properly.\n Expected:%s\n Recieved:%s", givenQuery, expectedQuery)
+	}
+}
+
+/* Uncomment to test
+func TestParseQueryFilePanic(t *testing.T) {
+	testPanic := parseQueryFile("./_test/DOESNTEXIST.sql")
+	if len(testPanic) > 0 {
+		t.Error("Did not panic out on a non-existent .sql file")
+	}
+}
+*/

--- a/queries/lib_test.go
+++ b/queries/lib_test.go
@@ -13,11 +13,11 @@ func TestParseQueryFilePass(t *testing.T) {
 	}
 }
 
-/* Uncomment to test
 func TestParseQueryFilePanic(t *testing.T) {
-	testPanic := parseQueryFile("./_test/DOESNTEXIST.sql")
-	if len(testPanic) > 0 {
-		t.Error("Did not panic out on a non-existent .sql file")
-	}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Did not panic out on a non-existent .sql file")
+		}
+	}()
+	_ = parseQueryFile("./_test/DOESNTEXIST.sql")
 }
-*/

--- a/queries/testQueries.go
+++ b/queries/testQueries.go
@@ -1,3 +1,3 @@
 package queries
 
-var testQuery = parseQueryFile(basePath + "/_test/test.sql")
+var testQuery = parseQueryFile("_test/test.sql")

--- a/queries/testQueries.go
+++ b/queries/testQueries.go
@@ -1,0 +1,3 @@
+package queries
+
+var testQuery = parseQueryFile(basePath + "/_test/test.sql")

--- a/queriesv2/export.go
+++ b/queriesv2/export.go
@@ -1,0 +1,11 @@
+package queries
+
+import (
+	"github.com/aria-afk/go-get-tickets/queriesv2/tickets"
+	"github.com/aria-afk/go-get-tickets/queriesv2/users"
+)
+
+var (
+	GetAllUsers   = users.GetAllUsers
+	GetAllTickets = tickets.GetAllTickets
+)

--- a/queriesv2/tickets/getAllTickets.go
+++ b/queriesv2/tickets/getAllTickets.go
@@ -1,0 +1,5 @@
+package tickets
+
+import "github.com/aria-afk/go-get-tickets/utils"
+
+var GetAllTickets = utils.ReadQueryFile("./getAllTickets.sql")

--- a/queriesv2/tickets/getAllTickets.sql
+++ b/queriesv2/tickets/getAllTickets.sql
@@ -1,0 +1,1 @@
+SELECT * FROM tickets;

--- a/queriesv2/users/getAllUsers.go
+++ b/queriesv2/users/getAllUsers.go
@@ -1,0 +1,5 @@
+package users
+
+import "github.com/aria-afk/go-get-tickets/utils"
+
+var GetAllUsers = utils.ReadQueryFile("./getAllUsers.sql")

--- a/queriesv2/users/getAllUsers.sql
+++ b/queriesv2/users/getAllUsers.sql
@@ -1,0 +1,1 @@
+SELECT * FROM users;

--- a/utils/readQueryFile.go
+++ b/utils/readQueryFile.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+)
+
+func ReadQueryFile(path string) string {
+	// Ensure file has a .sql extension
+	if path[len(path)-4:] != ".sql" {
+		panic(fmt.Sprintf("Provided file path is not a .sql file, given path: %s", path))
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		panic(fmt.Sprintf("Issue parsing query file [ %s ]\n Error: %s", path, err))
+	}
+	return string(data)
+}


### PR DESCRIPTION
This will get run on start so if we messed up it will just fail. (Rather than the prior implementation possibly failing once a query is called)

There are 2 considerations for this setup:

**All query folders should get a matching `.go` file and the variable names should be prepended with that dirs name.**

Example structure:

```
--queries/
--lib.go
--lib_test.go
--users.go
--users/
    --getUser.sql
    --deleteUser.sql

```

users.go
```golang
package queries

var UsersGetUser = parseQueryFile("users/getUser.sql")
var UsersDeleteUser = parseQueryFile("users/deleteUser.sql")
```

(Im also open to different naming suggestions like just `UsersDelete, UsersGet...`)

**If this package gets used somewhere else, it needs to be added to the path list**

```golang
func formatBasePath() string {
	absPath, err := filepath.Abs("./")
	if err != nil {
		panic(err)
	}
	basePath := filepath.Base(absPath)
	switch basePath {
	// Root dir
	case "go-get-tickets":
		return filepath.Join(absPath, "queries")
	// This package (for lib_test)
	case "queries":
		return absPath
	default:
		panic("Given working dir does not have a mapping yet, please add it.")
	}
}
```

This is really messy but it works... The idea is that it will be able to be run from any sub-package and or the main package. Honestly I didn't spend a ton of time working this out and there may be a more "correct" way to do it, however I don't think we will use it many packages so its probably ok. 

Also open to more ideas here.